### PR TITLE
feat: httpクライアントのラッパーを作りました

### DIFF
--- a/app/javascript/utils/requests.ts
+++ b/app/javascript/utils/requests.ts
@@ -1,0 +1,53 @@
+import axios from "axios";
+
+export default {
+  request(method, url, options) {
+    var promise = null;
+    var params = {};
+    var headers = {};
+
+    if (options.params) {
+      // リクエストパラメーターのセット
+      params = options.params;
+    }
+    if (options.headers) {
+      // カスタムヘッダーのセット
+      headers = options.headers;
+    }
+    if (options.auth) {
+      // ヘッダーにAuthorizationをセット
+      var authorization_header = JSON.parse(
+        localStorage.getItem("AuthenticationHeader")
+      );
+      headers = Object.assign(headers, authorization_header);
+    }
+    // RailsのCSRFトークンをセット
+    const token = document
+      .getElementsByName("csrf-token")[0]
+      .getAttribute("content");
+    headers["X-CSRF-TOKEN"] = token;
+
+    promise = axios({
+      method: method,
+      url: url,
+      data: params,
+      headers: headers
+    });
+    promise.catch(function() {
+      return console.log(promise);
+    });
+    return promise;
+  },
+  get(url, options) {
+    return this.request("get", url, options);
+  },
+  post(url, options) {
+    return this.request("post", url, options);
+  },
+  patch(url, options) {
+    return this.request("patch", url, options);
+  },
+  delete(url, options) {
+    return this.request("delete", url, options);
+  }
+};


### PR DESCRIPTION
axiosをラップしています。
例えば使用イメージは以下のような感じです

```typescript
// api/index.ts

import http from "@/utiles/requests";

export default {
  postCreateBlogInfo(params: any) {
    return http.post("/api/v1/blogs", { params: params });
  }
};
```

```typescript
// store/index.ts
    bloglist: [] = [];

    @Action({ rawError: true })
    async createBlog(param: BlogItem) {
        await blog.postCreateBlogInfo(param).then((response) => {
            this.context.commit(MUTATION.SET_SELECTED_BLOG_INFO, response.data);
        }).catch(response => console.log(response));
    }

    @Mutation
    [MUTATION.SET_SELECTED_BLOG_INFO](payload: BlogItem) {
        this.selectedBlogInfo = payload;
    }
```

```vue
// page/example.vue

<template>
   <bloglist :bloglist="bloglist"></bloglist>
</template>

<script>
  //　諸々省略
  export default class Any extends Vue {
      private blogStore = getModule(BlogStore, this.$store);

      get blogList(){
          return this.blogStore.bloglist;
      }
      
      postCreateBlogInfo(param: BlogItem) {
          try {
              this.blogStore.createBlog(param);
          } catch {
              console.log("error!");
          }
      }
  }
</script>
```