### PR TITLE
feat: date-fnsを追加しました

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "@rails/webpacker": "^4.2.0",
     "axios": "^0.19.0",
     "buefy": "^0.8.8",
+    "date-fns": "^2.8.1",
     "ts-loader": "^6.2.1",
     "turbolinks": "^5.2.0",
     "typescript": "^3.7.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2259,6 +2259,11 @@ dashdash@^1.12.0:
   dependencies:
     assert-plus "^1.0.0"
 
+date-fns@^2.8.1:
+  version "2.8.1"
+  resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-2.8.1.tgz#2109362ccb6c87c3ca011e9e31f702bc09e4123b"
+  integrity sha512-EL/C8IHvYRwAHYgFRse4MGAPSqlJVlOrhVYZ75iQBKrnv+ZedmYsgwH3t+BCDuZDXpoo07+q9j4qgSSOa7irJg==
+
 de-indent@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/de-indent/-/de-indent-1.0.2.tgz#b2038e846dc33baa5796128d0804b455b8c1e21d"


### PR DESCRIPTION
date-fnsというパッケージを追加しました。
このブランチを取り込んだあとは、`docker-compose run app yarn`コマンドを打ってください。

機能としてはISO2018(?)の時刻表記などをformatしてくれるものです。
何日後も日付とかも算出できます。

ググったら使い方は出でくるので調べて見てください。