### PR TITLE
Update master

### DIFF
--- a/app/javascript/api/auth/index.ts
+++ b/app/javascript/api/auth/index.ts
@@ -1,5 +1,5 @@
 import http from "@/utils/requests";
-const baseUrl = "http://118.27.22.110:8080/api/v1";
+const baseUrl = "http://localhost:8080/api/v1";
 
 export default {
   postSignInInfo(params: any) {

--- a/app/javascript/api/quest/index.ts
+++ b/app/javascript/api/quest/index.ts
@@ -1,5 +1,5 @@
 import http from "@/utils/requests";
-const baseUrl = "http://118.27.22.110:8080/api/v1";
+const baseUrl = "http://localhost:8080/api/v1";
 
 export default {
   getQuestList(params: any) {

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -7,6 +7,7 @@
 
     <%= stylesheet_link_tag 'application', media: 'all', 'data-turbolinks-track': 'reload' %>
     <%= javascript_pack_tag 'application', 'data-turbolinks-track': 'reload' %>
+    <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
   </head>
 
   <body>

--- a/app/views/main/index.html.erb
+++ b/app/views/main/index.html.erb
@@ -1,4 +1,4 @@
 <link rel="stylesheet" href="https://cdn.materialdesignicons.com/2.5.94/css/materialdesignicons.min.css">
 <div id="main"></div>
-<%= javascript_pack_tag 'main', 'data-turbolinks-track': 'reload' %>
+<%= javascript_packs_with_chunks_tag 'main', 'data-turbolinks-track': 'reload' %>
 <link rel="stylesheet" href="https://cdn.materialdesignicons.com/2.5.94/css/materialdesignicons.min.css">

--- a/config/puma/development.rb
+++ b/config/puma/development.rb
@@ -1,0 +1,38 @@
+# Puma can serve each request in a thread from an internal thread pool.
+# The `threads` method setting takes two numbers: a minimum and maximum.
+# Any libraries that use thread pools should be configured to match
+# the maximum value specified for Puma. Default is set to 5 threads for minimum
+# and maximum; this matches the default thread size of Active Record.
+#
+max_threads_count = ENV.fetch("RAILS_MAX_THREADS") { 5 }
+min_threads_count = ENV.fetch("RAILS_MIN_THREADS") { max_threads_count }
+threads min_threads_count, max_threads_count
+
+# Specifies the `port` that Puma will listen on to receive requests; default is 3000.
+#
+port        ENV.fetch("PORT") { 3000 }
+
+# Specifies the `environment` that Puma will run in.
+#
+environment ENV.fetch("RAILS_ENV") { "development" }
+
+# Specifies the `pidfile` that Puma will use.
+pidfile ENV.fetch("PIDFILE") { "tmp/pids/server.pid" }
+
+# Specifies the number of `workers` to boot in clustered mode.
+# Workers are forked web server processes. If using threads and workers together
+# the concurrency of the application would be max `threads` * `workers`.
+# Workers do not work on JRuby or Windows (both of which do not support
+# processes).
+#
+# workers ENV.fetch("WEB_CONCURRENCY") { 2 }
+
+# Use the `preload_app!` method when specifying a `workers` number.
+# This directive tells Puma to first boot the application and load code
+# before forking the application. This takes advantage of Copy On Write
+# process behavior so workers use less memory.
+#
+# preload_app!
+
+# Allow puma to be restarted by `rails restart` command.
+plugin :tmp_restart

--- a/config/puma/production.rb
+++ b/config/puma/production.rb
@@ -1,14 +1,3 @@
-# max_threads_count = ENV.fetch("RAILS_MAX_THREADS") { 5 }
-# min_threads_count = ENV.fetch("RAILS_MIN_THREADS") { max_threads_count }
-# threads min_threads_count, max_threads_count
-
-# port        ENV.fetch("PORT") { 3000 }
-# environment ENV.fetch("RAILS_ENV") { "development" }
-
-# pidfile ENV.fetch("PIDFILE") { "tmp/pids/server.pid" }
-# plugin :tmp_restart
-
-
 # 本番用(上は開発環境用。具体的にはコンソールに色々出る)
 threads_count = ENV.fetch("RAILS_MAX_THREADS") { 5 }.to_i
 threads threads_count, threads_count

--- a/config/webpack/environment.js
+++ b/config/webpack/environment.js
@@ -13,4 +13,5 @@ environment.config.merge({
 environment.plugins.prepend('VueLoaderPlugin', new VueLoaderPlugin())
 environment.loaders.prepend('vue', vue)
 environment.loaders.prepend('typescript', typescript)
+environment.splitChunks()
 module.exports = environment

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -1,0 +1,33 @@
+version: "3"
+services:
+  app: &app
+    command: bash -c "rm -f tmp/pids/server.pid &&  bundle exec rails s -e development -p 3000 -b '0.0.0.0'"
+    environment:
+      WEBPACKER_DEV_SERVER_HOST: webpacker
+      WEBPACKER_DEV_SERVER_PUBLIC: 0.0.0.0:3035
+    volumes:
+      - .:/borobo
+      - bundle:/usr/local/bundle
+      - public-data:/borobo/public
+      - tmp-data:/borobo/tmp
+      - log-data:/borobo/log
+    ports:
+      - "3000:3000"
+    depends_on:
+      - db
+    tty: true
+  webpacker:
+    <<: *app
+    build: .
+    command: bundle exec bin/webpack-dev-server
+    depends_on:
+      - app
+    ports:
+      - "3035:3035"
+    tty: false
+volumes:
+  bundle:
+  public-data:
+  tmp-data:
+  db_data:
+  log-data:

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -1,0 +1,29 @@
+version: "3"
+services:
+  app:
+    command: bash -c "rm -f tmp/pids/server.pid &&  bundle exec rails s -e production -p 3000 -b '0.0.0.0'"
+    volumes:
+      - .:/borobo
+      - bundle:/usr/local/bundle
+      - public-data:/borobo/public
+      - tmp-data:/borobo/tmp
+      - log-data:/borobo/log
+    ports:
+      - "3000:3000"
+    depends_on:
+      - db
+    tty: true
+  nginx:
+    build: containers/nginx
+    ports:
+      - "8080:80"
+    volumes:
+      - public-data:/borobo/public
+      - tmp-data:/borobo/tmp
+    tty: true
+volumes:
+  bundle:
+  public-data:
+  tmp-data:
+  db_data:
+  log-data:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,30 +9,6 @@ services:
       POSTGRES_PASSWORD: password
     tty: true
   app:
-    build: .
-    command: bash -c "rm -f tmp/pids/server.pid &&  bundle exec puma -C config/puma.rb"
-    volumes:
-      - .:/borobo
-      - bundle:/usr/local/bundle
-      - public-data:/borobo/public
-      - tmp-data:/borobo/tmp
-      - log-data:/borobo/log
-    ports:
-      - "3000:3000"
-    depends_on:
-      - db
-    tty: true
-  nginx:
-    build: containers/nginx
-    ports:
-      - "8080:80"
-    volumes:
-      - public-data:/borobo/public
-      - tmp-data:/borobo/tmp
-    tty: true
+   build: .
 volumes:
-  bundle:
-  public-data:
-  tmp-data:
   db_data:
-  log-data:


### PR DESCRIPTION
* APIエンドポイントの変更(その場しのぎ), スマートフォン表示への対応をしました
* 開発環境、本番環境ごとのdocker composeファイルを分けました
* 開発環境、本番環境ごとのPumaの設定ファイルに分けました
* webpackerのchunk loadをspliteにしました

これに伴い、docker composeの起動コマンドが
`docker-compose -f docker-compose.yml -f docker-compose.<env = dev or prod>.yml <command = build or up or down>`
に変更になります。

docker-compose.<env>.yml内で、適宜使用するpuma設定ファイルが切り替わっています。